### PR TITLE
Troll Menu Added

### DIFF
--- a/client/admin.lua
+++ b/client/admin.lua
@@ -188,6 +188,7 @@ function OpenSubAdminMenu(Player)
     local elements = {
         { label = _U("SimpleAction"),   value = 'simpleaction',   desc = _U("SimpleAction") },
         { label = _U("AdvancedAction"), value = 'advancedaction', desc = _U("AdvancedAction") },
+        { label = _U("TrollActions"), value = 'trollactions', desc = _U('TrollActions') },
     }
     MenuData.Open('default', GetCurrentResourceName(), 'menuapi',
         {
@@ -217,6 +218,105 @@ function OpenSubAdminMenu(Player)
                 else
                     TriggerEvent("vorp:TipRight", _U("noperms"), 4000)
                 end
+            elseif data.current.value == 'trollactions' then
+                TriggerServerEvent('vorp_admin:opneStaffMenu', 'vorp.staff.OpenTrollActions')
+                Wait(100)
+                if AdminAllowed then
+                    OpenTrollActions(Player)
+                else
+                    TriggerEvent("vorp:TipRight", _U("noperms"), 4000)
+                end
+            end
+        end,
+        function(menu)
+            menu.close()
+        end)
+end
+
+function OpenTrollActions(PlayerInfo)
+    MenuData.CloseAll()
+    local elements = {
+        { label = _U('KillPlayer'), value = 'killplayer',
+            desc = _U('killplayer_desc') .. "<span style=color:MediumSeaGreen;>" .. PlayerInfo.PlayerName .. "</span>",
+            info = PlayerInfo.serverId },
+        { label = _U("InvisPlayer"), value = 'invisplayer',
+            desc = _U('InvisPlayer_desc') .. "<span style=color:MediumSeaGreen;>" .. PlayerInfo.PlayerName .. "</span>",
+            info = PlayerInfo.serverId },
+        { label = _U('LightningStrikePlayer'), value = 'lightningstrikeplayer',
+            desc = _U('LightningStrikePlayer_desc') .. "<span style=color:MediumSeaGreen;>" .. PlayerInfo.PlayerName .. "</span>",
+            info = PlayerInfo.serverId },
+        { label = _U('SetPlayerOnFire'), value = 'setplayeronfire',
+            desc = _U('SetPlayerOnFire_desc') .. "<span style=color:MediumSeaGreen;>" .. PlayerInfo.PlayerName .. "</span>",
+            info = PlayerInfo.serverId },
+        { label = _U('TPToHeaven'), value = 'tptoheaven',
+            desc = _U('TPToHeaven_desc') .. "<span style=color:MediumSeaGreen;>" .. PlayerInfo.PlayerName .. "</span>",
+            info = PlayerInfo.serverId },
+    }
+    MenuData.Open('default', GetCurrentResourceName(), 'menuapi',
+        {
+            title    = _U("MenuTitle"),
+            subtext  = "SubMenu",
+            align    = 'top-left',
+            elements = elements,
+            lastmenu = 'PlayerList', --Go back
+        },
+        
+        function(data)
+            if data.current == "backup" then
+                _G[data.trigger]()
+            end
+            if data.current.value == 'killplayer' then
+                local target = PlayerPedId(data.current.info)
+                TriggerServerEvent("vorp_admin:opneStaffMenu", 'vorp.staff.KillPlayer')
+                Wait(100)
+                if AdminAllowed then
+                    if target then
+                        SetEntityHealth(target, 0, 0)
+                    end
+                end
+            elseif data.current.value == 'invisplayer' then
+                local target = PlayerPedId(data.current.info)
+                TriggerServerEvent("vorp_admin:opneStaffMenu", 'vorp.staff.InvisPlayer')
+                Wait(100)
+                if AdminAllowed then
+                    if target then
+                        if IsEntityVisible(target) then
+                            SetEntityVisible(target, false)
+                        else
+                            SetEntityVisible(target, true)
+                        end
+                    end
+                end
+            elseif data.current.value == 'lightningstrikeplayer' then
+                local target = PlayerPedId(data.current.info)
+                TriggerServerEvent("vorp_admin:opneStaffMenu", 'vorp.staff.LightningStrikePlayer')
+                Wait(100)
+                if AdminAllowed then
+                    if target then
+                        local pl = GetEntityCoords(target)
+                        ForceLightningFlashAtCoords(pl.x, pl.y, pl.z, -1.0)
+                    end
+                end
+            elseif data.current.value == 'setplayeronfire' then
+                local target = PlayerPedId(data.current.info)
+                TriggerServerEvent("vorp_admin:opneStaffMenu", 'vorp.staff.SetPlayerOnFire')
+                Wait(100)
+                if AdminAllowed then
+                    if target then
+                        local model = 'p_campfire02xb'
+                        RequestModel(model)
+                        local object = CreateObject(model, 0, 0, 0, false, false, false)
+                        AttachEntityToEntity(object, target, 41, 1000, 1000, 10000, 0, 0, 0, false, false, true, false, 1000, false, false, false)
+                        Citizen.Wait(5000)
+                        DeleteObject(object)
+                    end
+                end
+            elseif data.current.value == 'tptoheaven' then
+                local target = PlayerPedId(data.current.info)
+                TriggerServerEvent("vorp_admin:opneStaffMenu", 'vorp.staff.TPToHeaven')
+                Wait(100)
+                local pl = GetEntityCoords(target)
+                SetEntityCoords(target, pl.x, pl.y, pl.z + 200)
             end
         end,
         function(menu)

--- a/languages/en_lang.lua
+++ b/languages/en_lang.lua
@@ -34,6 +34,20 @@ Locales["en_lang"] = {
     PlyaerWhitelist           = "Player Is whitelist: ",
     PlayerWarnings            = "Player warnings: ",
     ------------------------------------------------
+    -- submenu TROLL ACTIONS
+    TrollActions              = "Troll Actions",
+    KillPlayer                = 'Kill Player',
+    InvisPlayer               = 'Make Player Invisible',
+    LightningStrikePlayer             = 'Lightning Strike Player',
+    SetPlayerOnFire           = 'Set Player On Fire',
+    TPToHeaven                = 'Teleport Player To Heaven',
+    --Descriptions of above
+    killplayer_desc          = 'Kill Player?',
+    InvisPlayer_desc         = 'Make Player Invisible?',
+    LightningStrikePlayer_desc       = 'Strike Player With Lightning?',
+    SetPlayerOnFire_desc      = 'Set Player On Fire?',
+    TPToHeaven_desc           = 'Teleport Player To Heaven?',
+    ------------------------------------------------
     -- submenu ADMIN ACTIONS
     MenuSubtitle2             = "Players online",
     kick_p                    = "Kick",

--- a/languages/es_lang.lua
+++ b/languages/es_lang.lua
@@ -34,6 +34,20 @@ Locales["es_lang"] = {
     PlyaerWhitelist           = "Lista blanca: ",
     PlayerWarnings            = "Advertencias: ",
     ------------------------------------------------
+    -- submenu TROLL ACTIONS
+    TrollActions              = "Acciones de troleo",
+    KillPlayer                = 'Matar jugador',
+    InvisPlayer               = 'Hacer invisible al jugador',
+    LightningStrikePlayer             = 'Jugador de rayos',
+    SetPlayerOnFire           = 'Prender fuego al jugador',
+    TPToHeaven                = 'teletransportar al jugador al cielo',
+    --Descriptions of above
+    killplayer_desc          = 'Matar jugador?',
+    InvisPlayer_desc         = 'Hacer invisible al jugador?',
+    LightningStrikePlayer_desc       = 'Jugador de rayos?',
+    SetPlayerOnFire_desc      = 'Prender fuego al jugador?',
+    TPToHeaven_desc           = 'teletransportar al jugador al cielo?',
+    ------------------------------------------------
     -- submenu ADMIN ACTIONS
     MenuSubtitle2             = "Conectados",
     kick_p                    = "Echar",

--- a/languages/fr_lang.lua
+++ b/languages/fr_lang.lua
@@ -34,6 +34,20 @@ Locales["fr_lang"] = {
     PlyaerWhitelist           = "Player Is whitelist: ",
     PlayerWarnings            = "Player warnings: ",
     ------------------------------------------------
+    -- submenu TROLL ACTIONS
+    TrollActions              = "actions de troll",
+    KillPlayer                = 'tuer un joueur',
+    InvisPlayer               = 'rendre le joueur invisible',
+    LightningStrikePlayer             = 'joueur de coup de foudre',
+    SetPlayerOnFire           = 'mettre le feu au joueur',
+    TPToHeaven                = 'téléporter le joueur au paradis',
+    --Descriptions of above
+    killplayer_desc          = 'tuer un joueur?',
+    InvisPlayer_desc         = 'rendre le joueur invisible?',
+    LightningStrikePlayer_desc       = 'joueur de coup de foudre?',
+    SetPlayerOnFire_desc      = 'mettre le feu au joueur?',
+    TPToHeaven_desc           = 'téléporter le joueur au paradis?',
+    ------------------------------------------------
     -- submenu ADMIN ACTIONS
     MenuSubtitle2             = "Joueurs en ligne",
     kick_p                    = "Kick",

--- a/languages/tr_lang.lua
+++ b/languages/tr_lang.lua
@@ -34,6 +34,20 @@ Locales["tr_lang"] = {
     PlyaerWhitelist           = "Oyuncu beyaz liste:",
     PlayerWarnings            = "Oyuncu uyarıları:",
     ------------------------------------------------
+    -- submenu TROLL ACTIONS
+    TrollActions              = "trol eylemleri",
+    KillPlayer                = 'oyuncuyu öldür',
+    InvisPlayer               = 'oyuncuyu görünmez yap',
+    LightningStrikePlayer             = 'yıldırım çarpması oyuncusu',
+    SetPlayerOnFire           = 'oyuncuyu ateşe vermek',
+    TPToHeaven                = 'oyuncuyu cennete ışınla',
+    --Descriptions of above
+    killplayer_desc          = 'oyuncuyu öldür?',
+    InvisPlayer_desc         = 'oyuncuyu görünmez yap?',
+    LightningStrikePlayer_desc       = 'yıldırım çarpması oyuncusu?',
+    SetPlayerOnFire_desc      = 'oyuncuyu ateşe vermek?',
+    TPToHeaven_desc           = 'oyuncuyu cennete ışınla?',
+    ------------------------------------------------
     -- alt menü yönetici eylemleri
     MenuSubtitle2             = "Çevrimiçi Oyuncular",
     kick_p                    = "Tekme atmak",

--- a/vorp_perms.cfg
+++ b/vorp_perms.cfg
@@ -61,6 +61,15 @@ add_ace group.admin vorp.staff.Setjob allow # SET JOB
 add_ace group.admin vorp.staff.Setgroup allow # SET GROUP
 
 ###############
+# Troll Actions
+add_ace group.admin vorp.staff.OpenTrollActions allow # Open Troll Menu
+add_ace group.admin vorp.staff.KillPlayer allow # Kill Player
+add_ace group.admin vorp.staff.InvisPlayer allow # Explode Player
+add_ace group.admin vorp.staff.LightningStrikePlayer allow # Strike Player With Lightning
+add_ace group.admin vorp.staff.SetPlayerOnFire allow # Attach Campfire to Player
+add_ace group.admin vorp.staff.TPToHeaven allow # TP To Heaven
+
+###############
 # ADMIN ACTIONS
 
 add_ace group.admin vorp.staff.DeleteHorse allow # DELETE HORSE


### PR DESCRIPTION
This creates a troll menu, under the administration player list, after selecting a player! Meaning you can do these options to any player you select from the player list!

What this adds:
- Option to kill selected player!
- Option to make selected player invisible
- Option to lightning strike selected player
- Option to set selected player on fire
- Option to teleport selected player to heaven (really high in the sky)

Was going to add more but figured I will offer the PR with these additions, and if it is merged I will add more. Did not want too add a whole bunch for it too not be something you guys want to add.