### PR TITLE
Change the Teleports > Teleport To Coordinates Menu Input Filter

### DIFF
--- a/client/teleport.lua
+++ b/client/teleport.lua
@@ -62,12 +62,15 @@ function Teleport()
                 TriggerServerEvent("vorp_admin:opneStaffMenu", "vorp.staff.TpCoords")
                 Wait(100)
                 if AdminAllowed then
-                    local myInput = Inputs("input", T.Menus.DefaultsInputs.confirm, T.Menus.MainTeleportOptions.InsertCoordsInput.placeholder, T.Menus.MainTeleportOptions.InsertCoordsInput.title, "text", T.Menus.MainTeleportOptions.InsertCoordsInput.errorMsg, "[0-9 \\-\\.]{5,60}")
+                    local myInput = Inputs("input", T.Menus.DefaultsInputs.confirm, T.Menus.MainTeleportOptions.InsertCoordsInput.placeholder, T.Menus.MainTeleportOptions.InsertCoordsInput.title, "text", T.Menus.MainTeleportOptions.InsertCoordsInput.errorMsg, '.*{5,60}')
                     TriggerEvent("vorpinputs:advancedInput", json.encode(myInput), function(result)
                         local coords = result
                         local admin = PlayerPedId()
                         if coords ~= "" and coords then
                             local finalCoords = {}
+                            coords = string.gsub(coords, "(vector[34])", "")
+                            coords = string.gsub(coords, "[^%d%. -]", "")
+
                             for i in string.gmatch(coords, "%S+") do
                                 finalCoords[#finalCoords + 1] = i
                             end


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
I help develop on a friend's server, and all of the staff were super frustrated that they had to reformat their coordinates before the input filter would accept them on the **Teleport To Coordinates** menu. This includes the coordinate formats that can be copied from the **Dev Tools > Coordinates Menu** options. 

I only changed about 3 lines, and was able to open up the filter, while keeping the same functionality.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
The **Teleports > Teleport To Coordinates** menu can accept various coordinate formats with minimal changes to the code.

### Explain the necessity of these changes and how they will impact the framework or its users.
Users of the vorp_admin resource will be able to continue teleporting to coordinates in the format they're used to, or they can paste in different styles of coordinate formats used in Lua/RedM.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.
After I made the changes to `client/teleport.lua`, I used the **Teleports > Teleport To Coordinate** menu for the following coordinate options:

-38.88 73.59 88.92
-38.88, 73.59, 88.92
{x = -38.88, y = 73.59, z = 88.92}
x=-38.88, y=73.59, z=88.92
vector3(-38.88, 73.59, 88.92)
vector4(-38.88, 73.59, 88.92, 356.5)

_Only the first three decimal numbers will be parsed, so the heading is ignored in the vector4 example._

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
None
